### PR TITLE
Split content scripts and downgrade permissions

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -1,0 +1,13 @@
+const getBundlephobiaLink = package => `https://bundlephobia.com/result?p=${package}`
+
+const sizeTransformer = ({ gzip, size }) => {
+  const parse = input => parseFloat(input).toFixed(1)
+  const format = input => input > 1048576
+    ? `${parse(input / 1048576)} MB` : input > 1024
+    ? `${parse(input / 1024)} KB` : `${input} B`
+
+  return {
+    gzip: format(gzip),
+    size: format(size),
+  }
+}

--- a/extension/js/github-content.js
+++ b/extension/js/github-content.js
@@ -1,0 +1,36 @@
+const getPackageNameFromGithubBody = bodyText => {
+  if (!bodyText) return
+
+  const npmOrYarnMatch = bodyText.match(/((npm i\w*)( )(-[a-zA-Z-]+\s)*([a-z0-9-\.\_\@\/]+))|(yarn add ([a-z0-9-\.\_\@\/]+))/i)
+  return npmOrYarnMatch && (npmOrYarnMatch[7] || npmOrYarnMatch[5])
+}
+
+const githubTransformer = npmPackage => ({ gzip, size }) => {
+  const badgeGenerator = (href, name, value) => `<a href="${href}"><div class="jsbs-badge-container"><div class="jsbs-badge-label">${name}</div><div class="jsbs-badge-value">${value}</div></div></a>`
+
+  const article = document.querySelector('article.markdown-body')
+  if (!article) return
+
+  const link = getBundlephobiaLink(npmPackage)
+  const div = document.createElement('div')
+  div.className = 'jsbs-github-container'
+  div.innerHTML = badgeGenerator(link, 'minified', size)
+    + badgeGenerator(link, 'minified + gzipped', gzip)
+
+  article.insertBefore(div, article.firstChild)
+}
+
+const main = () => {
+  const package = getPackageNameFromGithubBody(document.querySelector('body').innerHTML)
+  if (!package) return
+
+  const transformer = githubTransformer(package)
+
+  fetch(`https://bundlephobia.com/api/size?package=${package}`)
+    .then(response => response.json())
+    .then(sizeTransformer)
+    .then(transformer)
+    .catch(err => console.warn('Retrieving JS bundle size failed', { err }))
+}
+
+main()

--- a/extension/js/npmjs-content.js
+++ b/extension/js/npmjs-content.js
@@ -1,8 +1,8 @@
-const getPackageNameFromGithubBody = bodyText => {
-  if (!bodyText) return
+const getPackageNameFromNpm = url => {
+  if (!url) return
 
-  const npmOrYarnMatch = bodyText.match(/((npm i\w*)( )(-[a-zA-Z-]+\s)*([a-z0-9-\.\_\@\/]+))|(yarn add ([a-z0-9-\.\_\@\/]+))/i)
-  return npmOrYarnMatch && (npmOrYarnMatch[7] || npmOrYarnMatch[5])
+  const match = url.match(/(https:\/\/www.npmjs.com\/package\/)(.+)/i)
+  return match && match[2]
 }
 
 const npmTransformer = npmPackage => ({ gzip, size }) => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,8 +7,19 @@
   "version": "0.1.0",
   "content_scripts": [{
     "css": ["css/style.css"],
-    "js": ["js/background.js"],
-    "matches": ["https://www.npmjs.com/package/*", "https://github.com/*/*"]
+    "js": [
+      "js/content.js",
+      "js/github-content.js"
+    ],
+    "matches": ["https://github.com/*/*"]
+  },
+  {
+    "css": ["css/style.css"],
+    "js": [
+      "js/content.js",
+      "js/npmjs-content.js"
+    ],
+    "matches": ["https://www.npmjs.com/package/*"]
   }],
   "icons": {
     "16": "/icons/icon16.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,5 +26,5 @@
     "48": "icons/icon48.png",
    "128": "icons/icon128.png"
   },
-  "permissions": ["*://*/*"]
+  "permissions": ["https://bundlephobia.com/api/size"]
 }


### PR DESCRIPTION
Hello @vicrazumov 
I really like the concept of this little extension of yours, so thank you!

This PR aims to properly leverage the ability of webextension manifest by injecting in the right web pages only the needed code. 
This way adding support for other website in the future should also be easier, minimizing file size penalty.

Also, for Firefox to allow fetching resources on CSP protected pages, only the most fine grained host permissions are truly necessary. So I downgraded `"*://*/*"` to `"https://bundlephobia.com/api/size"` to be explicit about what URL you really need to access.

Tested on Firefox 71.0 and Chrome 79